### PR TITLE
スプリットを行えるようにする

### DIFF
--- a/src/bet.js
+++ b/src/bet.js
@@ -5,11 +5,11 @@ export class Bet {
   }
 
   add(amount) {
-    new Bet(this.amount + amount)
+    return new Bet(this.amount + amount)
   }
 
   remove() {
-    new Bet(0)
+    return new Bet(0)
   }
 
   isZero() {
@@ -17,7 +17,7 @@ export class Bet {
   }
 
   doubleDown() {
-    new Bet(this.amount, this.amount)
+    return new Bet(this.amount, this.amount)
   }
 
   totalAmount() {

--- a/src/bet.js
+++ b/src/bet.js
@@ -1,0 +1,26 @@
+export class Bet {
+  constructor(amount, doubleDownAmount = 0) {
+    this.amount = amount
+    this.doubleDownAmount = doubleDownAmount
+  }
+
+  add(amount) {
+    new Bet(this.amount + amount)
+  }
+
+  remove() {
+    new Bet(0)
+  }
+
+  isZero() {
+    return this.amount === 0
+  }
+
+  doubleDown() {
+    new Bet(this.amount, this.amount)
+  }
+
+  totalAmount() {
+    return this.amount + this.doubleDownAmount
+  }
+}

--- a/src/compare_score.js
+++ b/src/compare_score.js
@@ -4,12 +4,6 @@ export class CompareScore {
     this.dealerScore = dealerScore
   }
 
-  resultMessage() {
-    if (this.isPlayerVictory()) { return 'Winner: Player' }
-    if (this.isDealerVictory()) { return 'Winner: Dealer' }
-    return 'Result is Draw'
-  }
-
   isPlayerVictory() {
     if(this.playerScore.isBurst()) { return false }
     if(this.dealerScore.isBurst()) { return true }

--- a/src/dealer.js
+++ b/src/dealer.js
@@ -1,28 +1,37 @@
 import { CalculateScore } from "./calculate_score"
+import { Hand } from "./hand"
 
 export class Dealer {
-  constructor(hand) {
+  constructor(hand = new Hand([])) {
     this.hand = hand
     this.score = new CalculateScore(hand.cards)
   }
 
   cardFaceUp() {
-    new Dealer(this.hand.cardFaceUp())
+    return new Dealer(this.hand.cardFaceUp())
+  }
+
+  setupCard(cards) {
+    return new Dealer(new Hand(cards).cardFaceDown(), this.bet, this.reward)
   }
 
   isMustHit() {
-    this.score.isMustHit()
+    return this.score.isMustHit()
   }
 
   addCard(card) {
-    new Dealer(this.hand.addCard(card))
+    return new Dealer(this.hand.addCard(card))
   }
 
   isBlackJack() {
-    this.score.isBlackJack()
+    return this.score.isBlackJack()
+  }
+
+  isBurst() {
+    return this.score.isBurst()
   }
 
   displayHand() {
-    this.hand.display()
+    return this.hand.display()
   }
 }

--- a/src/dealer.js
+++ b/src/dealer.js
@@ -1,0 +1,28 @@
+import { CalculateScore } from "./calculate_score"
+
+export class Dealer {
+  constructor(hand) {
+    this.hand = hand
+    this.score = new CalculateScore(hand.cards)
+  }
+
+  cardFaceUp() {
+    new Dealer(this.hand.cardFaceUp())
+  }
+
+  isMustHit() {
+    this.score.isMustHit()
+  }
+
+  addCard(card) {
+    new Dealer(this.hand.addCard(card))
+  }
+
+  isBlackJack() {
+    this.score.isBlackJack()
+  }
+
+  displayHand() {
+    this.hand.display()
+  }
+}

--- a/src/hand.js
+++ b/src/hand.js
@@ -18,6 +18,11 @@ export class Hand {
   cardFaceUp() {
     return this
   }
+
+  isSplitEnable() {
+    if (this.cards.length !== 2) { return false }
+    return (this.cards[0].number === this.cards[1].number)
+  }
 }
 
 class FaceDownHand {
@@ -49,5 +54,9 @@ class FaceDownHand {
 
   cardFaceUp() {
     return new Hand(this.cards)
+  }
+
+  isSplitEnable() {
+    return false
   }
 }

--- a/src/hand.js
+++ b/src/hand.js
@@ -25,7 +25,11 @@ export class Hand {
   }
 
   isTwoAce() {
-    (this.cards.length === 2 && this.cards.every((card) => { return (card.number === 1) }))
+    if (this.cards.length !== 2) { return false }
+
+    this.cards.every((card) => {
+      return (card.number === 1)
+    })
   }
 }
 

--- a/src/hand.js
+++ b/src/hand.js
@@ -21,7 +21,7 @@ export class Hand {
 
   isSplitEnable() {
     if (this.cards.length !== 2) { return false }
-    return (this.cards[0].number === this.cards[1].number)
+    return (this.cards[0].value === this.cards[1].value)
   }
 }
 
@@ -57,6 +57,10 @@ class FaceDownHand {
   }
 
   isSplitEnable() {
+    return false
+  }
+
+  isTowAce() {
     return false
   }
 }

--- a/src/hand.js
+++ b/src/hand.js
@@ -23,6 +23,10 @@ export class Hand {
     if (this.cards.length !== 2) { return false }
     return (this.cards[0].value === this.cards[1].value)
   }
+
+  isTwoAce() {
+    (this.cards.length === 2 && this.cards.every((card) => { return (card.number === 1) }))
+  }
 }
 
 class FaceDownHand {
@@ -60,7 +64,7 @@ class FaceDownHand {
     return false
   }
 
-  isTowAce() {
+  isTwoAce() {
     return false
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,5 @@
-.game-result {
-  font-size: 32px;
-  margin: 16px;
-  text-align: center;
-  min-height: 48px;
-}
 .dealer {
+  margin-top: 32px;
   text-align: center;
 }
 .dealer-score {

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,10 @@
 }
 .player-field {
   height: 350px;
+  min-width: 350px;
+}
+.current-field {
+  background-color: #f4fff4;
 }
 .player-score {
   font-size: 32px;
@@ -22,6 +26,7 @@
   justify-content: center;
 }
 .action {
+  margin-top: 32px;
   text-align: center;
 }
 .button {

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@
   display: flex;
   justify-content: center;
 }
-.bet-button, .start-button, .hit-button, .double-button, .stay-button, .restart-button {
+.button {
   margin: 0 12px;
   font-size: 24px;
   width: 128px;

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,9 @@
   display: flex;
   justify-content: center;
 }
+.action {
+  text-align: center;
+}
 .button {
   margin: 0 12px;
   font-size: 24px;

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,8 @@
 .player {
   text-align: center;
   margin-top: 16px;
+  display: flex;
+  justify-content: space-around;
 }
 .player-field {
   height: 350px;

--- a/src/index.js
+++ b/src/index.js
@@ -110,21 +110,31 @@ class Game extends React.Component {
     })
 
     if(newScore.isBurst()) {
-      if (this.state.currentPlayerNumber < (this.state.players.length - 1)) {
-        return this.setState({ currentPlayer: this.state.currentPlayer + 1 })
+      const newPlayers = this.state.players.map((player) => {
+        if (player !== currentPlayer) {
+          return player
+        }
+        return { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 }
+      })
+
+      if (this.state.currentPlayer < (this.state.players.length - 1)) {
+        return this.setState({
+          currentPlayer: this.state.currentPlayer + 1, players: newPlayers
+        })
       }
 
       const dealerHand = this.state.dealerHand.cardFaceUp()
-      this.setState({
-        dealerHand: dealerHand,
-        progress: 'finish',
-        players: this.state.players.map((player) => {
-          if (player !== currentPlayer) {
-            return player
-          }
-          return { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 }
+
+      if (newPlayers.every((player) => { return (player.bet === 0) })) {
+        return this.setState({
+          dealerHand: dealerHand,
+          progress: 'finish',
+          players: newPlayers
         })
-      })
+      }
+
+      const dealerScore = new CalculateScore(dealerHand.cards)
+      this.stayAction(dealerHand, dealerScore, newPlayers)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,6 @@ class Game extends React.Component {
         chip: chip,
         reward: 0,
         progress: 'setup',
-        result: '',
         players: [{
           hand: new Hand([]),
           bet: 0,
@@ -66,7 +65,6 @@ class Game extends React.Component {
         chip: chip,
         reward: reward,
         progress: 'finish',
-        result: result.resultMessage(),
         players: [{
           hand: playerHand,
           bet: returnBet,
@@ -83,7 +81,6 @@ class Game extends React.Component {
       chip: chip,
       reward: 0,
       progress: 'start',
-      result: '',
       players: [{
         hand: playerHand,
         bet: bet,
@@ -113,13 +110,10 @@ class Game extends React.Component {
     })
 
     if(newScore.isBurst()) {
-      const dealerScore = new CalculateScore(this.state.dealerHand.cards)
-      const result = new CompareScore(newScore, dealerScore)
       const dealerHand = this.state.dealerHand.cardFaceUp()
       this.setState({
         dealerHand: dealerHand,
         progress: 'finish',
-        result: result.resultMessage(),
         players: this.state.players.map((player) => {
           if (player !== currentPlayer) {
             return player
@@ -165,11 +159,9 @@ class Game extends React.Component {
 
 
     if(playerScore.isBurst()) {
-      const result = new CompareScore(playerScore, dealerScore)
       return this.setState({
         dealerHand: dealerHand,
         progress: 'finish',
-        result: result.resultMessage(),
         players: [
           { hand: newHand, bet: 0, doubleDownBet: 0 }
         ]
@@ -195,11 +187,9 @@ class Game extends React.Component {
       const newScore = new CalculateScore(newHand.cards)
 
       if (newScore.isBurst()) {
-        const result = new CompareScore(playerScore, newScore)
         return this.setState({
           progress: 'finish',
           reward: player.bet + player.doubleDownBet,
-          result: result.resultMessage(),
         })
       }
 
@@ -212,7 +202,6 @@ class Game extends React.Component {
       return this.setState({
         dealerHand: dealerHand.cardFaceUp(),
         progress: 'finish',
-        result: result.resultMessage(),
         players: [
           { hand: player.hand, bet: 0, doubleDownBet: 0 }
         ]
@@ -224,14 +213,12 @@ class Game extends React.Component {
         dealerHand: dealerHand.cardFaceUp(),
         progress: 'finish',
         reward: player.bet + player.doubleDownBet,
-        result: result.resultMessage(),
       })
     }
 
     this.setState({
       dealerHand: dealerHand.cardFaceUp(),
       progress: 'finish',
-      result: result.resultMessage()
     })
   }
 
@@ -247,9 +234,6 @@ class Game extends React.Component {
 
     return (
       <div className="game">
-        <div className="game-result">
-          { this.state.result }
-        </div>
         <Chip chip={this.state.chip} role="game-chip" />
         <div className="game-board">
           <div className="dealer">
@@ -284,7 +268,7 @@ class Game extends React.Component {
                 this.setState({
                   chip: this.state.chip - 50,
                   players: [
-                    { hand: currentPlayer.hand, result: '', bet: currentPlayer.bet + 50, doubleDownBet: 0 }
+                    { hand: currentPlayer.hand, bet: currentPlayer.bet + 50, doubleDownBet: 0 }
                   ]
                 })
               }}

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,19 @@ class Game extends React.Component {
     }
   }
 
+  splitAction(player) {
+    const newPlayers = player.hand.cards.map((card) => {
+      return {
+        hand: new Hand([card]), bet: player.bet, doubleDownBet: player.doubleDownBet
+      }
+    })
+
+    this.setState({
+      chip: this.state.chip - player.bet,
+      players: newPlayers
+    })
+  }
+
   async doubleAction(dealerScore, player) {
     const bet = player.bet
     const chip = this.state.chip - bet
@@ -230,7 +243,8 @@ class Game extends React.Component {
           </div>
           <div className="player">
             {
-              this.state.players.map((player, index) => {
+              // 右側のプレイヤーからアクションを行う為、表示順を反転している
+              this.state.players.reverse().map((player, index) => {
                 const playerHand = player.hand
                 const playerScore = new CalculateScore(playerHand.cards)
 
@@ -247,68 +261,68 @@ class Game extends React.Component {
                 )
               })
             }
-            <div className="player-action">
-              <button
-                className="button bet-button"
-                disabled={this.state.progress !== 'setup'}
-                onClick={ () => {
-                  this.setState({
-                    chip: this.state.chip - 50,
-                    players: [
-                      { hand: currentPlayer.hand, result: '', bet: currentPlayer.bet + 50, doubleDownBet: 0 }
-                    ]
-                  })
-                }}
-              >
-                Bet
-              </button>
-              <button
-                className="button start-button"
-                disabled={this.state.bet === 0 || this.state.progress !== 'setup'}
-                onClick={ () => {
-                  this.setState(this.setup(this.state.chip, currentPlayer.bet))
-                }}
-              >
-                Start
-              </button>
-              <button
-                className="button hit-button"
-                disabled={this.state.progress !== 'start'}
-                onClick={ () => this.hitAction(currentPlayer) }
-              >
-                Hit
-              </button>
-              <button
-                className="button double-button"
-                disabled={this.state.progress !== 'start'}
-                onClick={ () => this.doubleAction(dealerScore, currentPlayer) }
-              >
-                Double
-              </button>
-              <button
-                className="button split-button"
-                disabled={!currentPlayer.hand.isSplitEnable()}
-                onClick={ () => null }
-              >
-                Split
-              </button>
-              <button
-                className="button stay-button"
-                disabled={this.state.progress !== 'start'}
-                onClick={() => {this.stayAction(dealerHand, dealerScore, currentPlayer)}}
-              >
-                Stay
-              </button>
-              <button
-                className="button restart-button"
-                disabled={this.state.progress !== 'finish'}
-                onClick={() => {
-                  this.setState(this.setup(this.state.chip + currentPlayer.bet + currentPlayer.doubleDownBet + this.state.reward, 0))
-                }}
-              >
-                Restart
-              </button>
-            </div>
+          </div>
+          <div className="action">
+            <button
+              className="button bet-button"
+              disabled={this.state.progress !== 'setup'}
+              onClick={ () => {
+                this.setState({
+                  chip: this.state.chip - 50,
+                  players: [
+                    { hand: currentPlayer.hand, result: '', bet: currentPlayer.bet + 50, doubleDownBet: 0 }
+                  ]
+                })
+              }}
+            >
+              Bet
+            </button>
+            <button
+              className="button start-button"
+              disabled={this.state.bet === 0 || this.state.progress !== 'setup'}
+              onClick={ () => {
+                this.setState(this.setup(this.state.chip, currentPlayer.bet))
+              }}
+            >
+              Start
+            </button>
+            <button
+              className="button hit-button"
+              disabled={this.state.progress !== 'start'}
+              onClick={ () => this.hitAction(currentPlayer) }
+            >
+              Hit
+            </button>
+            <button
+              className="button double-button"
+              disabled={this.state.progress !== 'start'}
+              onClick={ () => this.doubleAction(dealerScore, currentPlayer) }
+            >
+              Double
+            </button>
+            <button
+              className="button split-button"
+              disabled={(this.state.progress === 'finish' || !currentPlayer.hand.isSplitEnable())}
+              onClick={ () => {this.splitAction(currentPlayer)} }
+            >
+              Split
+            </button>
+            <button
+              className="button stay-button"
+              disabled={this.state.progress !== 'start'}
+              onClick={() => {this.stayAction(dealerHand, dealerScore, currentPlayer)}}
+            >
+              Stay
+            </button>
+            <button
+              className="button restart-button"
+              disabled={this.state.progress !== 'finish'}
+              onClick={() => {
+                this.setState(this.setup(this.state.chip + currentPlayer.bet + currentPlayer.doubleDownBet + this.state.reward, 0))
+              }}
+            >
+              Restart
+            </button>
           </div>
         </div>
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -194,14 +194,14 @@ class Game extends React.Component {
             </div>
             <div className="player-action">
               <button
-                className="bet-button"
+                className="button bet-button"
                 disabled={this.state.progress !== 'setup'}
                 onClick={ () => { this.setState({ chip: this.state.chip - 50, bet: this.state.bet + 50 }) }}
               >
                 Bet
               </button>
               <button
-                className="start-button"
+                className="button start-button"
                 disabled={this.state.bet === 0 || this.state.progress !== 'setup'}
                 onClick={ () => {
                   this.setState(this.setup(this.state.chip, this.state.bet))
@@ -210,28 +210,35 @@ class Game extends React.Component {
                 Start
               </button>
               <button
-                className="hit-button"
+                className="button hit-button"
                 disabled={this.state.progress !== 'start'}
                 onClick={ () => this.hitAction() }
               >
                 Hit
               </button>
               <button
-                className="double-button"
+                className="button double-button"
                 disabled={this.state.progress !== 'start'}
                 onClick={ () => this.doubleAction(dealerScore) }
               >
                 Double
               </button>
               <button
-                className="stay-button"
+                className="button split-button"
+                disabled={!playerHand.isSplitEnable()}
+                onClick={ () => null }
+              >
+                Split
+              </button>
+              <button
+                className="button stay-button"
                 disabled={this.state.progress !== 'start'}
                 onClick={() => {this.stayAction(dealerHand, dealerScore, playerScore, this.state.bet)}}
               >
                 Stay
               </button>
               <button
-                className="restart-button"
+                className="button restart-button"
                 disabled={this.state.progress !== 'finish'}
                 onClick={() => { this.setState(this.setup(this.state.chip + this.state.bet + this.state.doubleDownBet + this.state.reward, 0)) }}
               >

--- a/src/index.js
+++ b/src/index.js
@@ -95,15 +95,18 @@ class Game extends React.Component {
     this.state = this.setup(1000, 0)
   }
 
-  hitAction(player) {
+  hitAction(currentPlayer) {
     const newCard = this.state.deck.drawCard()
-    const newHand = player.hand.addCard(newCard)
+    const newHand = currentPlayer.hand.addCard(newCard)
     const newScore = new CalculateScore(newHand.cards)
 
     this.setState({
-      players: [
-        { hand: newHand, bet: player.bet, doubleDownBet: player.doubleDownBet }
-      ]
+      players: this.state.players.map((player) => {
+        if (player !== currentPlayer) {
+          return player
+        }
+        return { hand: newHand, bet: currentPlayer.bet, doubleDownBet: currentPlayer.doubleDownBet }
+      })
     })
 
     if(newScore.isBurst()) {
@@ -114,9 +117,12 @@ class Game extends React.Component {
         dealerHand: dealerHand,
         progress: 'finish',
         result: result.resultMessage(),
-        players: [
-          { hand: newHand, bet: 0, doubleDownBet: 0 }
-        ]
+        players: this.state.players.map((player) => {
+          if (player !== currentPlayer) {
+            return player
+          }
+          return { hand: newHand, bet: 0, doubleDownBet: 0 }
+        })
       })
     }
   }
@@ -229,6 +235,8 @@ class Game extends React.Component {
 
     // Player
     const currentPlayer = this.state.players[0]
+    // 右側のプレイヤーからアクションを行う為、表示順を反転している
+    const displayPlayers = [...this.state.players].reverse()
 
     return (
       <div className="game">
@@ -243,8 +251,7 @@ class Game extends React.Component {
           </div>
           <div className="player">
             {
-              // 右側のプレイヤーからアクションを行う為、表示順を反転している
-              this.state.players.reverse().map((player, index) => {
+              displayPlayers.map((player, index) => {
                 const playerHand = player.hand
                 const playerScore = new CalculateScore(playerHand.cards)
 

--- a/src/index.js
+++ b/src/index.js
@@ -137,19 +137,22 @@ class Game extends React.Component {
     })
   }
 
-  async doubleAction(dealerScore, player) {
-    const bet = player.bet
+  async doubleAction(dealerScore, currentPlayer) {
+    const bet = currentPlayer.bet
     const chip = this.state.chip - bet
 
     const newCard = this.state.deck.drawCard()
-    const newHand = player.hand.addCard(newCard)
+    const newHand = currentPlayer.hand.addCard(newCard)
     const playerScore = new CalculateScore(newHand.cards)
 
-    const newPlayer = { hand: newHand, bet: player.bet, doubleDownBet: bet }
+    const newPlayer = { hand: newHand, bet: bet, doubleDownBet: bet }
 
     this.setState({
       chip: chip,
-      players: [newPlayer]
+      players: this.state.players.map((player) => {
+        if (player !== currentPlayer) { return player }
+        return newPlayer
+      })
     })
 
     const _sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -162,9 +165,10 @@ class Game extends React.Component {
       return this.setState({
         dealerHand: dealerHand,
         progress: 'finish',
-        players: [
-          { hand: newHand, bet: 0, doubleDownBet: 0 }
-        ]
+        players: this.state.players.map((player) => {
+          if (player !== currentPlayer) { return player }
+          return { hand: newHand, bet: 0, doubleDownBet: 0 }
+        })
       })
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -123,11 +123,10 @@ class Game extends React.Component {
         })
       }
 
-      this.stayAction(dealerHand, dealerScore, newPlayers)
+      this.stayAction(dealerHand, dealerScore, newPlayers, this.state.currentPlayerIndex)
     }
   }
 
-  // TODO: エースのスプリットに対応する
   splitAction(currentPlayer) {
     const  newPlayers = this.state.players.map((player) => {
       if(player !== currentPlayer) { return player }
@@ -142,6 +141,21 @@ class Game extends React.Component {
       chip: this.state.chip - currentPlayer.bet,
       players: newPlayers
     })
+
+    if (!currentPlayer.hand.isTwoAce()) { return }
+
+    const finishPlayers = newPlayers.map((player) => {
+      const newCard = this.state.deck.drawCard()
+      const newHand = player.hand.addCard(newCard)
+      return { hand: newHand, bet: player.bet, doubleDownBet: player.doubleDownBet, reward: 0 }
+    })
+
+    const dealerHand = this.state.dealerHand
+    const dealerScore = new CalculateScore(dealerHand.cards)
+
+    console.log(finishPlayers)
+
+    this.stayAction(dealerHand, dealerScore, finishPlayers, finishPlayers.length)
   }
 
   async doubleAction(currentPlayer, dealerHand, dealerScore) {
@@ -179,12 +193,12 @@ class Game extends React.Component {
       }
     }
 
-    this.stayAction(dealerHand, dealerScore, newPlayers)
+    this.stayAction(dealerHand, dealerScore, newPlayers, this.state.currentPlayerIndex)
   }
 
-  stayAction(dealerHand, dealerScore, players) {
-    if (this.state.currentPlayerIndex < (players.length - 1)) {
-      return this.setState({ currentPlayerIndex: this.state.currentPlayerIndex + 1 })
+  stayAction(dealerHand, dealerScore, players, currentPlayerIndex) {
+    if (currentPlayerIndex < (players.length - 1)) {
+      return this.setState({ currentPlayerIndex: currentPlayerIndex + 1 })
     }
 
     if (dealerScore.isMustHit()) {
@@ -205,7 +219,7 @@ class Game extends React.Component {
         })
       }
 
-      return this.stayAction(newHand, newScore, players)
+      return this.stayAction(newHand, newScore, players, currentPlayerIndex)
     }
 
     const evaluatedPlayers = players.map((player) => {
@@ -318,7 +332,7 @@ class Game extends React.Component {
             <button
               className="button stay-button"
               disabled={this.state.progress !== 'start'}
-              onClick={() => {this.stayAction(dealerHand, dealerScore, this.state.players)}}
+              onClick={() => {this.stayAction(dealerHand, dealerScore, this.state.players, this.state.currentPlayerIndex)}}
             >
               Stay
             </button>

--- a/src/index.js
+++ b/src/index.js
@@ -100,23 +100,20 @@ class Game extends React.Component {
     const newHand = currentPlayer.hand.addCard(newCard)
     const newScore = new CalculateScore(newHand.cards)
 
+    const newPlayers = this.state.players.map((player) => {
+      if (player !== currentPlayer) {
+        return player
+      }
+      return newScore.isBurst() ?
+        { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 } :
+        { hand: newHand, bet: currentPlayer.bet, doubleDownBet: currentPlayer.doubleDownBet, reward: 0 }
+    })
+
     this.setState({
-      players: this.state.players.map((player) => {
-        if (player !== currentPlayer) {
-          return player
-        }
-        return { hand: newHand, bet: currentPlayer.bet, doubleDownBet: currentPlayer.doubleDownBet, reward: 0 }
-      })
+      players: newPlayers
     })
 
     if(newScore.isBurst()) {
-      const newPlayers = this.state.players.map((player) => {
-        if (player !== currentPlayer) {
-          return player
-        }
-        return { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 }
-      })
-
       if (this.state.currentPlayer < (this.state.players.length - 1)) {
         return this.setState({
           currentPlayer: this.state.currentPlayer + 1, players: newPlayers
@@ -164,29 +161,32 @@ class Game extends React.Component {
 
     const newPlayers = this.state.players.map((player) => {
       if (player !== currentPlayer) { return player }
-      return { hand: newHand, bet: bet, doubleDownBet: bet, reward: 0 }
+      return playerScore.isBurst() ?
+        { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 } :
+        { hand: newHand, bet: bet, doubleDownBet: bet, reward: 0 }
     })
 
-    this.setState({
-      chip: chip,
-      players: newPlayers
-    })
+    this.setState({ chip: chip, players: newPlayers })
 
     const _sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     await _sleep(300);
 
     const dealerHand = this.state.dealerHand.cardFaceUp()
 
-
     if(playerScore.isBurst()) {
-      return this.setState({
-        dealerHand: dealerHand,
-        progress: 'finish',
-        players: this.state.players.map((player) => {
-          if (player !== currentPlayer) { return player }
-          return { hand: newHand, bet: 0, doubleDownBet: 0, reward: 0 }
+      if (this.state.currentPlayer < (this.state.players.length - 1)) {
+        return this.setState({
+          currentPlayer: this.state.currentPlayer + 1, players: newPlayers
         })
-      })
+      }
+
+      if (newPlayers.every((player) => { return (player.bet === 0) })) {
+        return this.setState({
+          dealerHand: dealerHand,
+          progress: 'finish',
+          players: newPlayers
+        })
+      }
     }
 
     this.stayAction(dealerHand, dealerScore, newPlayers)

--- a/src/index.js
+++ b/src/index.js
@@ -264,9 +264,10 @@ class Game extends React.Component {
               displayPlayers.map((player, index) => {
                 const playerHand = player.hand
                 const playerScore = new CalculateScore(playerHand.cards)
+                const currentField = player === currentPlayer ? 'current-field' : ''
 
                 return (
-                  <div className="player-field" key={index}>
+                  <div className={`player-field ${currentField}`} key={index}>
                     <div className="player-score">Player: { playerScore.value() }</div>
                     <HandCards role="player-hand" cards={playerHand.display()} deck={this.state.deck} />
                     <div className="player-chips">

--- a/src/index.js
+++ b/src/index.js
@@ -138,15 +138,18 @@ class Game extends React.Component {
     }
   }
 
-  splitAction(player) {
-    const newPlayers = player.hand.cards.map((card) => {
-      return {
-        hand: new Hand([card]), bet: player.bet, doubleDownBet: player.doubleDownBet, reward: 0
-      }
-    })
+  splitAction(currentPlayer) {
+    const  newPlayers = this.state.players.map((player) => {
+      if(player !== currentPlayer) { return player }
+      return player.hand.cards.map((card) => {
+        return {
+          hand: new Hand([card]), bet: currentPlayer.bet, doubleDownBet: currentPlayer.doubleDownBet, reward: 0
+        }
+      })
+    }).flat()
 
     this.setState({
-      chip: this.state.chip - player.bet,
+      chip: this.state.chip - currentPlayer.bet,
       players: newPlayers
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ class Game extends React.Component {
           hand: new Hand([]),
           bet: 0,
           doubleDownBet: 0,
-        }]
+        }],
+        currentPlayer: 0
       }
     }
 
@@ -70,7 +71,8 @@ class Game extends React.Component {
           hand: playerHand,
           bet: returnBet,
           doubleDownBet: 0,
-        }]
+        }],
+        currentPlayer: 0,
       }
     }
 
@@ -86,7 +88,8 @@ class Game extends React.Component {
         hand: playerHand,
         bet: bet,
         doubleDownBet: 0,
-      }]
+      }],
+      currentPlayer: 0
     }
   }
 
@@ -177,6 +180,10 @@ class Game extends React.Component {
   }
 
   stayAction(dealerHand, dealerScore, player) {
+    if (this.state.currentPlayer < (this.state.players.length - 1)) {
+      return this.setState({ currentPlayer: this.state.currentPlayer + 1 })
+    }
+
     const playerScore = new CalculateScore(player.hand.cards)
 
     if (dealerScore.isMustHit()) {
@@ -234,7 +241,7 @@ class Game extends React.Component {
     const dealerScore = new CalculateScore(dealerHand.cards)
 
     // Player
-    const currentPlayer = this.state.players[0]
+    const currentPlayer = this.state.players[this.state.currentPlayer]
     // 右側のプレイヤーからアクションを行う為、表示順を反転している
     const displayPlayers = [...this.state.players].reverse()
 
@@ -286,7 +293,7 @@ class Game extends React.Component {
             </button>
             <button
               className="button start-button"
-              disabled={this.state.bet === 0 || this.state.progress !== 'setup'}
+              disabled={currentPlayer.bet === 0 || this.state.progress !== 'setup'}
               onClick={ () => {
                 this.setState(this.setup(this.state.chip, currentPlayer.bet))
               }}

--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,12 @@ class Game extends React.Component {
         deck: deck,
         dealerHand: new Hand([]),
         chip: chip,
-        reward: 0,
         progress: 'setup',
         players: [{
           hand: new Hand([]),
           bet: 0,
           doubleDownBet: 0,
+          reward: 0,
         }],
         currentPlayer: 0
       }
@@ -63,12 +63,12 @@ class Game extends React.Component {
         deck: deck,
         dealerHand: dealerHand,
         chip: chip,
-        reward: reward,
         progress: 'finish',
         players: [{
           hand: playerHand,
           bet: returnBet,
           doubleDownBet: 0,
+          reward: reward,
         }],
         currentPlayer: 0,
       }
@@ -79,12 +79,12 @@ class Game extends React.Component {
       deck: deck,
       dealerHand: dealerHand.cardFaceDown(),
       chip: chip,
-      reward: 0,
       progress: 'start',
       players: [{
         hand: playerHand,
         bet: bet,
         doubleDownBet: 0,
+        reward: 0,
       }],
       currentPlayer: 0
     }
@@ -255,7 +255,7 @@ class Game extends React.Component {
                     <div className="player-score">Player: { playerScore.value() }</div>
                     <HandCards role="player-hand" cards={playerHand.display()} deck={this.state.deck} />
                     <div className="player-chips">
-                      <Chip chip={this.state.reward} role="reward-chip" />
+                      <Chip chip={player.reward} role="reward-chip" />
                       <Chip chip={player.bet} role="player-bet" />
                       <Chip chip={player.doubleDownBet} role="double-down-bet" />
                     </div>
@@ -320,7 +320,10 @@ class Game extends React.Component {
               className="button restart-button"
               disabled={this.state.progress !== 'finish'}
               onClick={() => {
-                this.setState(this.setup(this.state.chip + currentPlayer.bet + currentPlayer.doubleDownBet + this.state.reward, 0))
+                const playersChip = this.state.players.reduce((sum, player) => {
+                  return sum + player.bet + player.doubleDownBet + player.reward
+                })
+                this.setState(this.setup(this.state.chip + playersChip, 0))
               }}
             >
               Restart

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,32 @@
+import { CalculateScore } from "./calculate_score"
+
+export class Player {
+  constructor(hand) {
+    this.hand = hand
+    this.score = new CalculateScore(hand.cards)
+  }
+
+  addCard(card) {
+    new Player(this.hand.addCard(card))
+  }
+
+  isBurst() {
+    this.score.isBurst()
+  }
+
+  isBlackJack() {
+    this.score.isBlackJack()
+  }
+
+  isTwoAce() {
+    this.hand.isTwoAce()
+  }
+
+  isSplitEnable() {
+    this.hand.isSplitEnable()
+  }
+
+  displayHand() {
+    this.hand.display()
+  }
+}

--- a/src/player.js
+++ b/src/player.js
@@ -1,32 +1,83 @@
 import { CalculateScore } from "./calculate_score"
+import { Hand } from "./hand"
+import { Bet } from "./bet"
+import { Reward } from "./reward"
 
 export class Player {
-  constructor(hand) {
+  constructor(hand = new Hand([]), bet = new Bet(0), reward = new Reward(0)) {
     this.hand = hand
     this.score = new CalculateScore(hand.cards)
+    this.bet = bet
+    this.reward = reward
+  }
+
+  betAmount() {
+    return this.bet.amount
+  }
+
+  doubleDownAmount() {
+    return this.bet.doubleDownAmount
+  }
+
+  rewardAmount() {
+    return this.reward.amount
+  }
+
+  totalReturnAmount() {
+    return this.betAmount() + this.doubleDownAmount() + this.rewardAmount()
+  }
+
+  doubleDown() {
+    return new Player(this.hand, this.bet.doubleDown(), this.reward)
+  }
+
+  hasBet() {
+    return !this.bet.isZero()
+  }
+
+  addBet(amount) {
+    return (new Player(this.hand, this.bet.add(amount), this.reward))
+  }
+
+  removeBet() {
+    return new Player(this.hand, this.bet.remove(), this.reward)
+  }
+
+  setupCard(cards) {
+    return new Player(new Hand(cards), this.bet, this.reward)
   }
 
   addCard(card) {
-    new Player(this.hand.addCard(card))
+    return new Player(this.hand.addCard(card), this.bet, this.reward)
+  }
+
+  addReward(reward = this.bet.totalAmount()) {
+    return new Player(this.hand, this.bet, new Reward(reward))
+  }
+
+  splitHand() {
+    return this.hand.cards.map((card) => {
+      return new Player(new Hand([card]), this.bet, this.reward)
+    })
   }
 
   isBurst() {
-    this.score.isBurst()
+    return this.score.isBurst()
   }
 
   isBlackJack() {
-    this.score.isBlackJack()
+    return this.score.isBlackJack()
   }
 
   isTwoAce() {
-    this.hand.isTwoAce()
+    return this.hand.isTwoAce()
   }
 
   isSplitEnable() {
-    this.hand.isSplitEnable()
+    return this.hand.isSplitEnable()
   }
 
   displayHand() {
-    this.hand.display()
+    return this.hand.display()
   }
 }

--- a/src/reward.js
+++ b/src/reward.js
@@ -4,6 +4,6 @@ export class Reward {
   }
 
   add(amount) {
-    new Reward(this.amount + amount)
+    return new Reward(this.amount + amount)
   }
 }

--- a/src/reward.js
+++ b/src/reward.js
@@ -1,0 +1,9 @@
+export class Reward {
+  constructor(amount) {
+    this.amount = amount
+  }
+
+  add(amount) {
+    new Reward(this.amount + amount)
+  }
+}


### PR DESCRIPTION
- 同数字の場合はスプリットして手札を分けられるようにする
- エース2枚の場合は追加できるカードを1枚ずつにする
- ディーラーとプレイヤーの関係は`1対1`ではなく`1対n`
- ベットと報酬をクラスにする
- ディーラーとプレイヤーをクラスにして、各処理を委譲する